### PR TITLE
cache descriptor refactors

### DIFF
--- a/cache_descriptor.go
+++ b/cache_descriptor.go
@@ -1,0 +1,115 @@
+// Cache descriptor file related models and functions.
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+// result stores how the keys are different in two cache descriptor.
+type result struct {
+	removedIgnored []string
+	removed        []string
+	changed        []string
+	matching       []string
+	addedIgnored   []string
+	added          []string
+}
+
+// triggerNewCache reports whether a new cache needs to be generated or not.
+func (r result) triggerNewCache() bool {
+	return len(r.removed) > 0 || len(r.changed) > 0 || len(r.added) > 0
+}
+
+// compare compares two cache descriptor file and return the differences.
+func compare(old map[string]string, new map[string]string) (r result) {
+	newCopy := make(map[string]string, len(new))
+	for k, v := range new {
+		newCopy[k] = v
+	}
+
+	for oldPth, oldIndicator := range old {
+		newIndicator, ok := newCopy[oldPth]
+		switch {
+		case !ok && oldIndicator == "-":
+			r.removedIgnored = append(r.removedIgnored, oldPth)
+		case !ok:
+			r.removed = append(r.removed, oldPth)
+		case oldIndicator != newIndicator:
+			r.changed = append(r.changed, oldPth)
+		default:
+			r.matching = append(r.matching, oldPth)
+		}
+
+		delete(newCopy, oldPth)
+	}
+
+	for newPth, newIndicator := range newCopy {
+		if newIndicator == "-" {
+			r.addedIgnored = append(r.addedIgnored, newPth)
+		} else {
+			r.added = append(r.added, newPth)
+		}
+	}
+
+	return
+}
+
+// cacheDescriptor creates a cache descriptor for a given cache_path - change_indicator_path mapping.
+func cacheDescriptor(indicatorByCachePth map[string]string, method ChangeIndicator) (map[string]string, error) {
+	descriptor := map[string]string{}
+	for pth, indicatorPth := range indicatorByCachePth {
+		if len(indicatorPth) == 0 {
+			// this file's changes does not fluctuates existing cache invalidation
+			descriptor[pth] = "-"
+			continue
+		}
+
+		var indicator string
+		var err error
+		if method == MD5 {
+			indicator, err = fileContentHash(indicatorPth)
+		} else {
+			indicator, err = fileModtime(indicatorPth)
+		}
+		if err != nil {
+			return nil, err
+		}
+		descriptor[pth] = indicator
+	}
+	return descriptor, nil
+}
+
+// fileContentHash returns file's md5 content hash.
+func fileContentHash(pth string) (string, error) {
+	f, err := os.Open(pth)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("Failed to close file (%s), error: %+v", pth, err)
+		}
+	}()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// fileModtime returns a file's modtime as a Unix timestamp representation.
+func fileModtime(pth string) (string, error) {
+	fi, err := os.Stat(pth)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d", fi.ModTime().Unix()), nil
+}

--- a/cache_descriptor_test.go
+++ b/cache_descriptor_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+func Test_Test_cacheDescriptorModTime(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("cache")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %s", err)
+		return
+	}
+
+	pths := map[string]string{
+		filepath.Join(tmpDir, "subdir", "file1"): "some content",
+	}
+
+	// store time frame to test mod time change indicator method
+	start := time.Now()
+	// start and end dates needs to be rounded to second, since file info stores modtime in second precision
+	start = time.Date(start.Year(), start.Month(), start.Day(), start.Hour(), start.Minute(), start.Second(), 0, start.Location())
+	createDirStruct(t, pths)
+	end := time.Now()
+	end = time.Date(end.Year(), end.Month(), end.Day(), end.Hour(), end.Minute(), end.Second(), 0, end.Location())
+
+	t.Log("mod time method")
+	{
+		descriptor, err := cacheDescriptor(map[string]string{filepath.Join(tmpDir, "subdir", "file1"): filepath.Join(tmpDir, "subdir", "file1")}, MODTIME)
+		if err != nil {
+			t.Errorf("cacheDescriptor() error = %v, wantErr %v", err, false)
+			return
+		}
+
+		if len(descriptor) != 1 {
+			t.Errorf("want 1 descriptor item, got: %d", len(descriptor))
+			return
+		}
+
+		for _, modTimeStr := range descriptor {
+			modTime, err := strconv.Atoi(modTimeStr)
+			if err != nil {
+				t.Errorf("failed to int parse: %s, error: %s", modTimeStr, err)
+				return
+			}
+			mod := time.Unix(int64(modTime), 0)
+			if start.Before(mod) || end.After(mod) {
+				t.Errorf("invalid modtime (%v) should be > %v && < %v", mod, start, end)
+				return
+			}
+		}
+	}
+}
+func Test_cacheDescriptor(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("cache")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %s", err)
+		return
+	}
+
+	pths := map[string]string{
+		filepath.Join(tmpDir, "subdir", "file1"): "some content",
+		filepath.Join(tmpDir, "subdir", "file2"): "",
+	}
+
+	createDirStruct(t, pths)
+
+	tests := []struct {
+		name                string
+		indicatorByCachePth map[string]string
+		method              ChangeIndicator
+		descriptor          map[string]string
+		wantErr             bool
+	}{
+		{
+			name:                "no change indicator",
+			indicatorByCachePth: map[string]string{filepath.Join(tmpDir, "subdir", "file1"): ""},
+			method:              MD5,
+			descriptor:          map[string]string{filepath.Join(tmpDir, "subdir", "file1"): "-"},
+			wantErr:             false,
+		},
+		{
+			name:                "content hash method",
+			indicatorByCachePth: map[string]string{filepath.Join(tmpDir, "subdir", "file1"): filepath.Join(tmpDir, "subdir", "file2")},
+			method:              MD5,
+			descriptor:          map[string]string{filepath.Join(tmpDir, "subdir", "file1"): "d41d8cd98f00b204e9800998ecf8427e"}, // empty string MD5 hash
+			wantErr:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			descriptor, err := cacheDescriptor(tt.indicatorByCachePth, tt.method)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("cacheDescriptor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(descriptor, tt.descriptor) {
+				t.Errorf("cacheDescriptor() = %v, want %v", descriptor, tt.descriptor)
+			}
+		})
+	}
+}
+
+func Test_compare(t *testing.T) {
+	tests := []struct {
+		name string
+		old  map[string]string
+		new  map[string]string
+		want result
+	}{
+		{
+			name: "empty test",
+			old:  map[string]string{},
+			new:  map[string]string{},
+			want: result{},
+		},
+		{
+			name: "removed",
+			old:  map[string]string{"pth": "indicator"},
+			new:  map[string]string{},
+			want: result{removed: []string{"pth"}},
+		},
+		{
+			name: "ignored removed",
+			old:  map[string]string{"pth": "-"},
+			new:  map[string]string{},
+			want: result{removedIgnored: []string{"pth"}},
+		},
+		{
+			name: "changed",
+			old:  map[string]string{"pth": "indicator1"},
+			new:  map[string]string{"pth": "indicator2"},
+			want: result{changed: []string{"pth"}},
+		},
+		{
+			name: "matching",
+			old:  map[string]string{"pth": "indicator"},
+			new:  map[string]string{"pth": "indicator"},
+			want: result{matching: []string{"pth"}},
+		},
+		{
+			name: "added",
+			old:  map[string]string{},
+			new:  map[string]string{"pth": "indicator"},
+			want: result{added: []string{"pth"}},
+		},
+		{
+			name: "ignored added",
+			old:  map[string]string{},
+			new:  map[string]string{"pth": "-"},
+			want: result{addedIgnored: []string{"pth"}},
+		},
+		{
+			name: "complex",
+			old: map[string]string{
+				"removedPth":        "indicator",
+				"ignoredRemovedPth": "-",
+				"changed":           "indicator1",
+				"matching":          "indicator",
+				// "added":             "indicator",
+				// "ignoredAdded":      "-",
+			},
+			new: map[string]string{
+				// "removedPth":        "indicator",
+				// "ignoredRemovedPth": "-",
+				"changed":      "indicator2",
+				"matching":     "indicator",
+				"added":        "indicator",
+				"ignoredAdded": "-",
+			},
+			want: result{
+				removed:        []string{"removedPth"},
+				removedIgnored: []string{"ignoredRemovedPth"},
+				changed:        []string{"changed"},
+				matching:       []string{"matching"},
+				added:          []string{"added"},
+				addedIgnored:   []string{"ignoredAdded"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotR := compare(tt.old, tt.new); !reflect.DeepEqual(gotR, tt.want) {
+				t.Errorf("compare() = %v, want %v", gotR, tt.want)
+			}
+		})
+	}
+}
+
+func Test_result_triggerNewCache(t *testing.T) {
+	type fields struct {
+		removedIgnored []string
+		removed        []string
+		changed        []string
+		matching       []string
+		addedIgnored   []string
+		added          []string
+	}
+	tests := []struct {
+		name            string
+		removedIgnored  []string
+		removed         []string
+		changed         []string
+		matching        []string
+		addedIgnored    []string
+		added           []string
+		triggerNewCache bool
+	}{
+		// do not trigger new cache
+		{
+			name:            "empty",
+			triggerNewCache: false,
+		},
+		{
+			name:            "ignored removed",
+			removedIgnored:  []string{"pth"},
+			triggerNewCache: false,
+		},
+		{
+			name:            "matching",
+			matching:        []string{"pth"},
+			triggerNewCache: false,
+		},
+		{
+			name:            "ignored added",
+			addedIgnored:    []string{"pth"},
+			triggerNewCache: false,
+		},
+		// trigger new cache
+		{
+			name:            "removed",
+			removed:         []string{"pth"},
+			triggerNewCache: true,
+		},
+		{
+			name:            "changed",
+			changed:         []string{"pth"},
+			triggerNewCache: true,
+		},
+		{
+			name:            "added",
+			added:           []string{"pth"},
+			triggerNewCache: true,
+		},
+		{
+			name:            "complex",
+			removedIgnored:  []string{"pth"},
+			removed:         []string{"pth"},
+			changed:         []string{"pth"},
+			matching:        []string{"pth"},
+			addedIgnored:    []string{"pth"},
+			added:           []string{"pth"},
+			triggerNewCache: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := result{
+				removedIgnored: tt.removedIgnored,
+				removed:        tt.removed,
+				changed:        tt.changed,
+				matching:       tt.matching,
+				addedIgnored:   tt.addedIgnored,
+				added:          tt.added,
+			}
+			if got := r.triggerNewCache(); got != tt.triggerNewCache {
+				t.Errorf("result.triggerNewCache() = %v, want %v", got, tt.triggerNewCache)
+			}
+		})
+	}
+}

--- a/cache_path.go
+++ b/cache_path.go
@@ -1,3 +1,4 @@
+// Cache path and ignore path related functions.
 package main
 
 import (

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/fileutil"
+
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -221,14 +223,14 @@ func Test_parseIgnoreList(t *testing.T) {
 	}
 }
 
-func createDirStruct(t *testing.T, pths []string) {
-	for _, pth := range pths {
+func createDirStruct(t *testing.T, contentByPth map[string]string) {
+	for pth, content := range contentByPth {
 		dir := filepath.Dir(pth)
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			t.Fatalf("failed to create dir: %s", err)
 			return
 		}
-		if _, err := os.Create(pth); err != nil {
+		if err := fileutil.WriteStringToFile(pth, content); err != nil {
 			t.Fatalf("failed to create file: %s", err)
 			return
 		}
@@ -242,9 +244,9 @@ func Test_expandPath(t *testing.T) {
 		return
 	}
 
-	pths := []string{
-		filepath.Join(tmpDir, "subdir", "file1"),
-		filepath.Join(tmpDir, "subdir", "file2"),
+	pths := map[string]string{
+		filepath.Join(tmpDir, "subdir", "file1"): "",
+		filepath.Join(tmpDir, "subdir", "file2"): "",
 	}
 	createDirStruct(t, pths)
 
@@ -288,9 +290,9 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 		return
 	}
 
-	pths := []string{
-		filepath.Join(tmpDir, "subdir", "file1"),
-		filepath.Join(tmpDir, "subdir", "file2"),
+	pths := map[string]string{
+		filepath.Join(tmpDir, "subdir", "file1"): "",
+		filepath.Join(tmpDir, "subdir", "file2"): "",
 	}
 	createDirStruct(t, pths)
 

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -231,7 +231,7 @@ func createDirStruct(t *testing.T, contentByPth map[string]string) {
 			return
 		}
 		if err := fileutil.WriteStringToFile(pth, content); err != nil {
-			t.Fatalf("failed to create file: %s", err)
+			t.Fatalf("failed to write file: %s", err)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1,3 +1,12 @@
+// Cache Push step keeps the project's cache in sync with the project's current state based on the defined files to be cached and ignored.
+//
+// Files to be cached are described by a path and an optional descriptor file path.
+// Files to be cached can be referred by direct file path while multiple files can be selected by referring the container directory.
+// Optional indicator represents a files, based on which the step synchronizes the given file(s).
+// Syntax: file/path/to/cache, dir/to/cache, file/path/to/cache -> based/on/this/file, dir/to/cache -> based/on/this/file
+//
+// Ignore items are used to ignore certain file(s) from a directory to be cached or to mark that certain file(s) not relevant in cache synchronization.
+// Syntax: not/relevant/file/or/pattern, !file/or/pattern/to/remove/from/cache
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -4,24 +4,20 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/sliceutil"
 	glob "github.com/ryanuber/go-glob"
 )
 
@@ -212,7 +208,7 @@ func ProcessFiles(indicatorHashMap, filePathMap map[string]string, pathList, ign
 					switch storeMode {
 					case STORE:
 						if indicator == MD5 {
-							fileMD5, err := getFileContentMD5(path)
+							fileMD5, err := fileContentHash(path)
 							if err != nil {
 								return err
 							}
@@ -311,89 +307,32 @@ func LoadPreviousFilePathMap() (map[string]string, bool, error) {
 }
 
 // CompareFilePathMaps ...
-func (cacheModel *CacheModel) CompareFilePathMaps(currentFilePathsMap map[string]string) (bool, error) {
-	triggerNewCache := false
-	logLineCount := 0
-
-	for prevKey, prevValue := range cacheModel.PreviousFilePathMap {
-		currentValue, ok := currentFilePathsMap[prevKey]
-		if !ok {
-			log.Warnf("REMOVED: %s", prevKey)
-			if prevValue == "-" {
-				log.Donef("- Ignored")
-				if !cacheModel.DebugMode {
-					if logLineCount >= 9 {
-						log.Printf("[List truncated, turn on DebugMode to see the whole change list]")
-						return true, nil
-					}
-				}
-				logLineCount++
-			} else {
-				triggerNewCache = true
-				if !cacheModel.DebugMode {
-					if logLineCount >= 9 {
-						log.Printf("[List truncated, turn on DebugMode to see the whole change list]")
-						return true, nil
-					}
-				}
-				logLineCount++
+func CompareFilePathMaps(previousFilePathMap, currentFilePathsMap map[string]string, debugMode bool) bool {
+	logDebugPaths := func(paths []string) {
+		if debugMode {
+			for _, pth := range paths {
+				log.Debugf("- %s", pth)
 			}
-		} else {
-			if currentValue != prevValue {
-				log.Warnf("CHANGED: %s, Current: %s != Previous: %s", prevKey, currentValue, prevValue)
-				triggerNewCache = true
-				if !cacheModel.DebugMode {
-					if logLineCount >= 9 {
-						log.Printf("[List truncated, turn on DebugMode to see the whole change list]")
-						return true, nil
-					}
-				}
-				logLineCount++
-			}
-		}
-		delete(cacheModel.PreviousFilePathMap, prevKey)
-		delete(currentFilePathsMap, prevKey)
-	}
-
-	for remainingKey, remainingValue := range currentFilePathsMap {
-		log.Warnf("ADDED: %s", remainingKey)
-		if remainingValue == "-" {
-			log.Donef("- Ignored")
-			if !cacheModel.DebugMode {
-				if logLineCount >= 9 {
-					log.Printf("[List truncated, turn on DebugMode to see the whole change list]")
-					return true, nil
-				}
-			}
-			logLineCount++
-		} else {
-			triggerNewCache = true
-			if !cacheModel.DebugMode {
-				if logLineCount >= 9 {
-					log.Printf("[List truncated, turn on DebugMode to see the whole change list]")
-					return true, nil
-				}
-			}
-			logLineCount++
 		}
 	}
 
-	return triggerNewCache, nil
-}
+	result := compare(previousFilePathMap, currentFilePathsMap)
 
-func cleanDuplicatePaths(paths []string) []string {
-	cleanedPaths := []string{}
-	for _, item := range paths {
-		if item == "" {
-			continue
-		}
-		cleanPath := path.Clean(item)
-		if !sliceutil.IsStringInSlice(cleanPath, cleanedPaths) {
-			cleanedPaths = append(cleanedPaths, cleanPath)
-		}
-	}
+	log.Warnf("Previous cache is invalid, new cache will be generated:")
+	log.Warnf("%d files needs to be removed", len(result.removed))
+	logDebugPaths(result.removed)
+	log.Warnf("%d files has changed", len(result.changed))
+	logDebugPaths(result.changed)
+	log.Warnf("%d files added", len(result.added))
+	logDebugPaths(result.added)
+	log.Debugf("%d ignored files removed", len(result.removedIgnored))
+	logDebugPaths(result.removedIgnored)
+	log.Debugf("%d files did not change", len(result.matching))
+	logDebugPaths(result.matching)
+	log.Debugf("%d ignored files added", len(result.addedIgnored))
+	logDebugPaths(result.addedIgnored)
 
-	return cleanedPaths
+	return result.triggerNewCache()
 }
 
 // CleanPaths ...
@@ -413,7 +352,7 @@ func CleanPaths(pathList, ignorePathList []string, indicatorMethod ChangeIndicat
 		if len(indicator) > 0 {
 			var indicatorFileChangeIndicator string
 			if indicatorMethod == MD5 {
-				indicatorFileChangeIndicator, err = getFileContentMD5(indicator)
+				indicatorFileChangeIndicator, err = fileContentHash(indicator)
 				if err != nil {
 					return nil, nil, nil, err
 				}
@@ -469,30 +408,6 @@ func uploadArchive(cacheAPIURL string) error {
 		return tryToUploadArchive(uploadURL, cacheArchivePath)
 	}
 	return nil
-}
-
-func getFileContentMD5(filePath string) (string, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return "", err
-	}
-
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Errorf("Failed to close file (%s), error: %+v", filePath, err)
-		}
-	}()
-
-	h := md5.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
-func timespecToTime(ts syscall.Timespec) time.Time {
-	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
 }
 
 func getCacheUploadURL(cacheAPIURL string, fileSizeInBytes int64) (string, error) {
@@ -652,7 +567,7 @@ func main() {
 		}
 		cacheModel.FilePathMap = filePathsMap
 
-		recacheRequired, err = cacheModel.CompareFilePathMaps(filePathsMap)
+		recacheRequired = CompareFilePathMaps(cacheModel.PreviousFilePathMap, filePathsMap, cacheModel.DebugMode)
 		if err != nil {
 			log.Errorf("Failed to compare file path maps, error: %+v", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -577,11 +577,6 @@ func main() {
 		cacheModel.FilePathMap = filePathsMap
 
 		recacheRequired = CompareFilePathMaps(cacheModel.PreviousFilePathMap, filePathsMap, cacheModel.DebugMode)
-		if err != nil {
-			log.Errorf("Failed to compare file path maps, error: %+v", err)
-			os.Exit(1)
-		}
-
 		if recacheRequired {
 			log.Printf("- File changes found")
 			log.Printf("- Done")


### PR DESCRIPTION
- cache.go and cache_test.go renamed to cache_path.go and cache_path_test.go
- cache descriptor and related functions moved to cache_descriptor.go
- cleanDuplicatePaths unused function removed
- CompareFilePathMaps func updates