### PR TITLE
Tool 1100 yarn workspace support

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -318,6 +318,10 @@ workflows:
             ln -s $LINKED_FILES/test_cache_file.txt $CACHE_PATH/mysymlink
             ln $LINKED_FILES/test_cache_file.txt $CACHE_PATH/myhardlink
 
+            # symlink to a non-existent file
+            cd $CACHE_PATH
+            ln -s nonexistent_target $CACHE_PATH/invalid_symlink
+
             # symlink to a directory
             ln -s $LINKED_FILES $CACHE_PATH/symlink_dir
 
@@ -378,6 +382,11 @@ workflows:
 
             if [ "$(< $CACHE_PATH/mysymlink)" != "$(< $LINKED_FILES/test_cache_file.txt)" ]; then
               echo "file content mismatch"
+              exit 1
+            fi
+
+            if [ ! -L $CACHE_PATH/invalid_symlink ]; then
+              echo "symlink does not exist"
               exit 1
             fi
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -380,8 +380,8 @@ workflows:
               exit 1
             fi
 
-            if [ "$(< $CACHE_PATH/mysymlink)" != "$(< $LINKED_FILES/test_cache_file.txt)" ]; then
-              echo "file content mismatch"
+            if [ "$($CACHE_PATH/mysymlink)" != "$($LINKED_FILES/test_cache_file.txt)" ]; then
+              echo "symlink path mismatch"
               exit 1
             fi
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,8 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   # define these in your .bitrise.secrets.yml
-  # - BITRISE_CACHE_API_URL: $BITRISE_CACHE_API_URL # use file url scheme (file://) to create a cache archive in a local directory
-  - BITRISE_CACHE_API_URL: file:///Users/lpusok/Develop/go/src/github.com/bitrise-steplib/steps-cache-push/cachetest
+  - BITRISE_CACHE_API_URL: $BITRISE_CACHE_API_URL # use file url scheme (file://) to create a cache archive in a local directory
   - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
 
 workflows:
@@ -445,30 +444,6 @@ workflows:
               echo "archive_info.json not found as first file in archive"
               exit 1
             fi
-
-  test-yarn:
-    steps:
-    - change-workdir:
-        title: Switch working dir
-        inputs:
-        - path: /Users/lpusok/Develop/hunfencing-master
-        - is_create_path: true
-    - script:
-        title: Create sample files
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            yarn install
-    - path::./:
-        title: Step Test
-        is_always_run: true
-        run_if: true
-        is_skippable: false
-        inputs:
-        - compress_archive: true
-        - is_debug_mode: true
-        - cache_paths: "node_modules"
 
   # ----------------------------------------------------------------
   # --- Utility workflows

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -281,17 +281,17 @@ workflows:
       Tests if most of the FS file types are supported.
     envs:
     - TMP_DIR: $ORIG_BITRISE_SOURCE_DIR/_tmp_fs_check
-    - CACHE_PATH: |
-        $TMP_DIR
+    - CACHE_PATH: $TMP_DIR/cache
+    - LINKED_FILES: $TMP_DIR/target
     steps:
     - script:
         title: Cleanup $TMP_DIR and archive tmp files
         inputs:
         - content: rm -rf "$TMP_DIR" "/tmp/cache-archive.tar" "/tmp/cache-info.json"
     - change-workdir:
-        title: Switch working dir to $TMP_DIR
+        title: Switch working dir to $CACHE_PATH
         inputs:
-        - path: $TMP_DIR
+        - path: $CACHE_PATH
         - is_create_path: true
     - script:
         title: Create sample files
@@ -302,20 +302,24 @@ workflows:
             set -ex
 
             # file in root
-            echo "content" > $TMP_DIR/test_file1.txt
+            echo "content" > $CACHE_PATH/test_file1.txt
 
             # file in subdir
-            mkdir $TMP_DIR/subdir
-            echo "content" > $TMP_DIR/subdir/test_file.mp3
+            mkdir $CACHE_PATH/subdir
+            echo "content" > $CACHE_PATH/subdir/test_file.mp3
 
             # single dir
-            mkdir $TMP_DIR/single_dir
+            mkdir $CACHE_PATH/single_dir
 
+            mkdir $LINKED_FILES
             # symlink to a temp file
-            rm -rf /tmp/test_cache_file.txt
-            echo "content" > /tmp/test_cache_file.txt
-            ln -s /tmp/test_cache_file.txt $TMP_DIR/mysymlink
-            ln /tmp/test_cache_file.txt $TMP_DIR/myhardlink
+            rm -rf $LINKED_FILES/test_cache_file.txt
+            echo "content" > $LINKED_FILES/test_cache_file.txt
+            ln -s $LINKED_FILES/test_cache_file.txt $CACHE_PATH/mysymlink
+            ln $LINKED_FILES/test_cache_file.txt $CACHE_PATH/myhardlink
+
+            # symlink to a directory
+            ln -s $LINKED_FILES $CACHE_PATH/symlink_dir
 
     - path::./:
         title: Step Test
@@ -334,43 +338,51 @@ workflows:
             #!/bin/bash
             set -ex
             
-            # remove TMP_DIR to cleanup
-            rm -rf $TMP_DIR
+            # remove CACHE_PATH to cleanup
+            rm -rf $CACHE_PATH
+            mkdir $CACHE_PATH
+            cd $CACHE_PATH
+
             # extract the archive
             tar -xPf /tmp/cache-archive.tar
 
-            if [ -d $TMP_DIR/single_dir ]; then
+            if [ -d $CACHE_PATH/single_dir ]; then
               echo "dir should not exist"
               exit 1
             fi
 
-            if [ ! -f $TMP_DIR/test_file1.txt ]; then
+            if [ ! -f $CACHE_PATH/test_file1.txt ]; then
               echo "file should exist"
               exit 1
             fi
 
-            if [ ! -f $TMP_DIR/subdir/test_file.mp3 ]; then
+            if [ ! -f $CACHE_PATH/subdir/test_file.mp3 ]; then
               echo "file should exist"
               exit 1
             fi
 
-            if [ ! -f $TMP_DIR/mysymlink ]; then
+            if [ ! -f $CACHE_PATH/mysymlink ]; then
               echo "file should exist"
               exit 1
             fi
 
-            if [ ! -f $TMP_DIR/myhardlink ]; then
+            if [ ! -f $CACHE_PATH/myhardlink ]; then
               echo "file should exist"
               exit 1
             fi
 
-            if [ "$(< $TMP_DIR/myhardlink)" != "$(< /tmp/test_cache_file.txt)" ]; then
+            if [ "$(< $CACHE_PATH/myhardlink)" != "$(< $LINKED_FILES/test_cache_file.txt)" ]; then
               echo "file content mismatch"
               exit 1
             fi
 
-            if [ "$(< $TMP_DIR/mysymlink)" != "$(< /tmp/test_cache_file.txt)" ]; then
+            if [ "$(< $CACHE_PATH/mysymlink)" != "$(< $LINKED_FILES/test_cache_file.txt)" ]; then
               echo "file content mismatch"
+              exit 1
+            fi
+
+            if [ $(cd -P "$CACHE_PATH/symlink_dir" && pwd) != "$LINKED_FILES" ]; then
+              echo "symlink directory path mismatch"
               exit 1
             fi
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,8 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   # define these in your .bitrise.secrets.yml
-  - BITRISE_CACHE_API_URL: $BITRISE_CACHE_API_URL # use file url scheme (file://) to create a cache archive in a local directory
+  # - BITRISE_CACHE_API_URL: $BITRISE_CACHE_API_URL # use file url scheme (file://) to create a cache archive in a local directory
+  - BITRISE_CACHE_API_URL: file:///Users/lpusok/Develop/go/src/github.com/bitrise-steplib/steps-cache-push/cachetest
   - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
 
 workflows:
@@ -444,6 +445,30 @@ workflows:
               echo "archive_info.json not found as first file in archive"
               exit 1
             fi
+
+  test-yarn:
+    steps:
+    - change-workdir:
+        title: Switch working dir
+        inputs:
+        - path: /Users/lpusok/Develop/hunfencing-master
+        - is_create_path: true
+    - script:
+        title: Create sample files
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            yarn install
+    - path::./:
+        title: Step Test
+        is_always_run: true
+        run_if: true
+        is_skippable: false
+        inputs:
+        - compress_archive: true
+        - is_debug_mode: true
+        - cache_paths: "node_modules"
 
   # ----------------------------------------------------------------
   # --- Utility workflows

--- a/cache_descriptor.go
+++ b/cache_descriptor.go
@@ -82,8 +82,8 @@ func cacheDescriptor(indicatorByCachePth map[string]string, method ChangeIndicat
 			continue
 		}
 
-		var indicator string
 		var err error
+		var indicator string
 		if method == MD5 {
 			indicator, err = fileContentHash(indicatorPth)
 		} else {

--- a/cache_path.go
+++ b/cache_path.go
@@ -212,9 +212,7 @@ func interleave(indicatorByPth map[string]string, excludeByPattern map[string]bo
 		} else if len(indicator) == 0 {
 			// the file's own content fluctuates existing cache invalidation
 			indicator = pth
-		} else {
-			// the file's indicator content fluctuates existing cache invalidation
-		}
+		} // else: the file's indicator content fluctuates existing cache invalidation
 
 		indicatorByCachePth[pth] = indicator
 	}

--- a/cache_path.go
+++ b/cache_path.go
@@ -1,4 +1,14 @@
 // Cache path and ignore path related functions.
+//
+// Ignoring symlink target changes for cache invalidation, as we expect
+// the symlinks to be yarn workspace symlink: https://yarnpkg.com/blog/2018/02/15/nohoist/.
+// The symlinks are included in the cache, just not chhecked if the target they point to is changed.
+// If case it is a link to a directory outside of the cached paths (e.g. yarn workspaces),
+// will not add the linked directory to the cache, and will not invalidate the cache if it changes,
+// as we expect them to be part of the repository.
+// If it links to a directory included in the cache already, then also ignoring it.
+// The directory contents will be added to the cache as regular files, no need to check them twice.
+// Symlinks to files are also ignored.
 package main
 
 import (
@@ -11,16 +21,6 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	glob "github.com/ryanuber/go-glob"
 )
-
-// Ignoring symlink target changes for cache invalidation, as we expect
-// the symlinks to be yarn workspace symlink: https://yarnpkg.com/blog/2018/02/15/nohoist/.
-// The symlinks are included in the cache, just not chhecked if the target they point to is changed.
-// If case it is a link to a directory outside of the cached paths (e.g. yarn workspaces),
-// will not add the linked directory to the cache, and will not invalidate the cache if it changes,
-// as we expect them to be part of the repository.
-// If it links to a directory included in the cache already, then also ignoring it.
-// The directory contents will be added to the cache as regular files, no need to check them twice.
-// Symlinks to files are also ignored.
 
 // parseIncludeListItem separates path to cache and change indicator path.
 func parseIncludeListItem(item string) (string, string) {

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -359,14 +359,16 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 	createDirStruct(t, pths)
 
 	linkFilePath := filepath.Join(tmpDir, "dir_with_symlink", "link_file")
-	invalidTargetLinkPath := filepath.Join(tmpDir, "dir_with_symlink", "link_invalid")
-	linkDirPath := filepath.Join(tmpDir, "dir_with_symlink", "link_dir")
 	if err := os.Symlink(filepath.Join(tmpDir, "dir_with_symlink", "file"), linkFilePath); err != nil {
 		t.Fatalf("failed to create symlink, error: %s", err)
 	}
+
+	linkDirPath := filepath.Join(tmpDir, "dir_with_symlink", "link_dir")
 	if err := os.Symlink(filepath.Join(tmpDir), linkDirPath); err != nil {
 		t.Fatalf("failed to create symlink, error: %s", err)
 	}
+
+	invalidTargetLinkPath := filepath.Join(tmpDir, "dir_with_symlink", "link_invalid")
 	if err := os.Symlink("nonexistent_target", invalidTargetLinkPath); err != nil {
 		t.Fatalf("failed to create symlink, error: %s", err)
 	}

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/fileutil"
-
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -244,40 +246,93 @@ func Test_expandPath(t *testing.T) {
 		return
 	}
 
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Warnf("failed to remove directory, error: %s", err)
+		}
+	}()
+
 	pths := map[string]string{
-		filepath.Join(tmpDir, "subdir", "file1"): "",
-		filepath.Join(tmpDir, "subdir", "file2"): "",
+		filepath.Join(tmpDir, "subdir", "file1"):                   "",
+		filepath.Join(tmpDir, "subdir", "file2"):                   "",
+		filepath.Join(tmpDir, "link", "file"):                      "",
+		filepath.Join(tmpDir, "link_dir", "subdir", "file"):        "",
+		filepath.Join(tmpDir, "not_cached_dir", "not_cached_file"): "",
 	}
 	createDirStruct(t, pths)
 
+	linkFilePath := filepath.Join(tmpDir, "link", "symlink_file")
+	if err := os.Symlink(filepath.Join(tmpDir, "link", "file"), linkFilePath); err != nil {
+		t.Errorf("setup: failed to create symlink, error: %s", err)
+	}
+
+	linkDirPath := filepath.Join(tmpDir, "link_dir", "symlink_dir_outside_cache")
+	if err := os.Symlink(filepath.Join(tmpDir, "link_dir", "not_cached_dir"), linkDirPath); err != nil {
+		t.Errorf("setup: failed to create symlink, error: %s", err)
+	}
+
 	tests := []struct {
-		name    string
-		pth     string
-		pths    []string
-		wantErr bool
+		name           string
+		pth            string
+		regularFiles   []string
+		irregularPaths []string
+		wantErr        bool
 	}{
 		{
-			name:    "list files in a directory",
-			pth:     filepath.Join(tmpDir, "subdir"),
-			pths:    []string{filepath.Join(tmpDir, "subdir", "file1"), filepath.Join(tmpDir, "subdir", "file2")},
-			wantErr: false,
+			name:           "list files in a directory",
+			pth:            filepath.Join(tmpDir, "subdir"),
+			regularFiles:   []string{filepath.Join(tmpDir, "subdir", "file1"), filepath.Join(tmpDir, "subdir", "file2")},
+			irregularPaths: nil,
+			wantErr:        false,
 		},
 		{
-			name:    "puts file path in an array",
-			pth:     filepath.Join(tmpDir, "subdir", "file1"),
-			pths:    []string{filepath.Join(tmpDir, "subdir", "file1")},
-			wantErr: false,
+			name:           "puts file path in an array",
+			pth:            filepath.Join(tmpDir, "subdir", "file1"),
+			regularFiles:   []string{filepath.Join(tmpDir, "subdir", "file1")},
+			irregularPaths: nil,
+			wantErr:        false,
+		},
+		{
+			name:           "single symlink file",
+			pth:            linkFilePath,
+			regularFiles:   nil,
+			irregularPaths: []string{linkFilePath},
+			wantErr:        false,
+		},
+		{
+			name:           "single symlink directory",
+			pth:            linkDirPath,
+			regularFiles:   nil,
+			irregularPaths: []string{linkDirPath},
+			wantErr:        false,
+		},
+		{
+			name:           "directory with symlink to file in cache dir",
+			pth:            filepath.Join(tmpDir, "link"),
+			regularFiles:   []string{filepath.Join(tmpDir, "link", "file")},
+			irregularPaths: []string{linkFilePath},
+			wantErr:        false,
+		},
+		{
+			name:           "directory with symlink to dir outside of cache dir",
+			pth:            filepath.Join(tmpDir, "link_dir"),
+			regularFiles:   []string{filepath.Join(tmpDir, "link_dir", "subdir", "file")},
+			irregularPaths: []string{linkDirPath},
+			wantErr:        false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := expandPath(tt.pth)
+			got1, got2, err := expandPath(tt.pth)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("expandPath() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.pths) {
-				t.Errorf("expandPath() = %v, want %v", got, tt.pths)
+			if !reflect.DeepEqual(got1, tt.regularFiles) {
+				t.Errorf("expandPath() = %v want %v", got1, tt.regularFiles)
+			}
+			if !reflect.DeepEqual(got2, tt.irregularPaths) {
+				t.Errorf("expandPath() = %v, want %v", got2, tt.irregularPaths)
 			}
 		})
 	}
@@ -290,11 +345,27 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 		return
 	}
 
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Warnf("failed to remove directory, error: %s", err)
+		}
+	}()
+
 	pths := map[string]string{
-		filepath.Join(tmpDir, "subdir", "file1"): "",
-		filepath.Join(tmpDir, "subdir", "file2"): "",
+		filepath.Join(tmpDir, "subdir", "file1"):          "",
+		filepath.Join(tmpDir, "subdir", "file2"):          "",
+		filepath.Join(tmpDir, "dir_with_symlink", "file"): "",
 	}
 	createDirStruct(t, pths)
+
+	linkFilePath := filepath.Join(tmpDir, "dir_with_symlink", "link_file")
+	linkDirPath := filepath.Join(tmpDir, "dir_with_symlink", "link_dir")
+	if err := os.Symlink(filepath.Join(tmpDir, "dir_with_symlink", "file"), linkFilePath); err != nil {
+		t.Fatalf("failed to create symlink, error: %s", err)
+	}
+	if err := os.Symlink(filepath.Join(tmpDir), linkDirPath); err != nil {
+		t.Fatalf("failed to create symlink, error: %s", err)
+	}
 
 	if err := os.Setenv("NORMALIZE_INDICATOR_BY_PATH_TMP_DIR", tmpDir); err != nil {
 		t.Fatalf("failed to set NORMALIZE_INDICATOR_BY_PATH_TMP_DIR: %s", err)
@@ -340,8 +411,20 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 		{
 			name:            "expands path if it is a dir",
 			indicatorByPath: map[string]string{filepath.Join(tmpDir, "subdir"): ""},
-			normalized:      map[string]string{filepath.Join(tmpDir, "subdir", "file1"): "", filepath.Join(tmpDir, "subdir", "file2"): ""},
-			wantErr:         false,
+			normalized: map[string]string{
+				filepath.Join(tmpDir, "subdir", "file1"): "",
+				filepath.Join(tmpDir, "subdir", "file2"): "",
+			},
+			wantErr: false,
+		},
+		{
+			name:            "set symlink indicator to ignore file for cache invalidation",
+			indicatorByPath: map[string]string{filepath.Join(tmpDir, "dir_with_symlink"): ""},
+			normalized: map[string]string{
+				filepath.Join(tmpDir, "dir_with_symlink", "file"): "",
+				linkFilePath: "-",
+				linkDirPath:  "-",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -507,6 +590,66 @@ func Test_interleave(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.indicatorByCachePth) {
 				t.Errorf("interleave() = %v, want %v", got, tt.indicatorByCachePth)
+			}
+		})
+	}
+}
+
+func Test_isSymlink(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("setup: failed to create tmp dir, error: %s", err)
+	}
+
+	tmpFile, err := ioutil.TempFile(tmpDir, "")
+	if err != nil {
+		t.Errorf("setup: failed to create tmp file, error: %s", err)
+	}
+
+	linkPth := path.Join(tmpDir, "symlink")
+	if err := os.Symlink(tmpFile.Name(), linkPth); err != nil {
+		t.Errorf("setup: failed to create symlink, error: %s", err)
+	}
+
+	linkDirPth := path.Join(tmpDir, "symlink_dir")
+	if err := os.Symlink(tmpDir, linkDirPth); err != nil {
+		t.Errorf("setup: failed to create symlink, error: %s", err)
+	}
+
+	tests := []struct {
+		name    string
+		pth     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "symlink to file",
+			pth:     linkPth,
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "symlink to dir",
+			pth:     linkDirPth,
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "regurlar file",
+			pth:     tmpFile.Name(),
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isSymlink(tt.pth)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isSymlink() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isSymlink() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -359,11 +359,15 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 	createDirStruct(t, pths)
 
 	linkFilePath := filepath.Join(tmpDir, "dir_with_symlink", "link_file")
+	invalidTargetLinkPath := filepath.Join(tmpDir, "dir_with_symlink", "link_invalid")
 	linkDirPath := filepath.Join(tmpDir, "dir_with_symlink", "link_dir")
 	if err := os.Symlink(filepath.Join(tmpDir, "dir_with_symlink", "file"), linkFilePath); err != nil {
 		t.Fatalf("failed to create symlink, error: %s", err)
 	}
 	if err := os.Symlink(filepath.Join(tmpDir), linkDirPath); err != nil {
+		t.Fatalf("failed to create symlink, error: %s", err)
+	}
+	if err := os.Symlink("nonexistent_target", invalidTargetLinkPath); err != nil {
 		t.Fatalf("failed to create symlink, error: %s", err)
 	}
 
@@ -422,8 +426,9 @@ func Test_normalizeIndicatorByPath(t *testing.T) {
 			indicatorByPath: map[string]string{filepath.Join(tmpDir, "dir_with_symlink"): ""},
 			normalized: map[string]string{
 				filepath.Join(tmpDir, "dir_with_symlink", "file"): "",
-				linkFilePath: "-",
-				linkDirPath:  "-",
+				linkFilePath:          "-",
+				linkDirPath:           "-",
+				invalidTargetLinkPath: "-",
 			},
 		},
 	}
@@ -616,6 +621,11 @@ func Test_isSymlink(t *testing.T) {
 		t.Errorf("setup: failed to create symlink, error: %s", err)
 	}
 
+	invalidTargetLinkPth := path.Join(tmpDir, "link_invalid")
+	if err := os.Symlink("nonexistent_target", invalidTargetLinkPth); err != nil {
+		t.Errorf("setup: failed to create symlink, error: %s", err)
+	}
+
 	tests := []struct {
 		name    string
 		pth     string
@@ -631,6 +641,12 @@ func Test_isSymlink(t *testing.T) {
 		{
 			name:    "symlink to dir",
 			pth:     linkDirPth,
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "invalid target",
+			pth:     invalidTargetLinkPth,
 			want:    true,
 			wantErr: false,
 		},


### PR DESCRIPTION

If finding a symlink, we just ignore it as far as cache invalidation goes.
Yarn workspaces can create symlinks to directories outside of the node_modules folder, and do not want to follow these.
If the symlink (file or directory) points inside the cached folder, then I also do not want to follow those, as the files will be part of the cache anyway.
Yarn cache creates symlinks to executables (this seems to work currently)

```
Yarn Workspaces, this does not work:
https://yarnpkg.com/lang/en/docs/workspaces/
https://yarnpkg.com/blog/2018/02/15/nohoist/

❯❯❯ ls -al node_modules
total 8
drwxr-xr-x   5 lpusok  staff  160 Oct  1 18:44 .
drwxr-xr-x  10 lpusok  staff  320 Oct  1 18:44 ..
-rw-r--r--   1 lpusok  staff  274 Oct  1 18:44 .yarn-integrity
lrwxr-xr-x   1 lpusok  staff   13 Oct  1 18:44 a -> ../packages/a
lrwxr-xr-x   1 lpusok  staff   13 Oct  1 18:44 b -> ../packages/b
```