### PR TITLE
Act 465

### DIFF
--- a/cache_path.go
+++ b/cache_path.go
@@ -63,11 +63,6 @@ func parseIgnoreList(list []string) map[string]bool {
 			continue
 		}
 
-		ex, ok := ignoreByPath[pth]
-		if ok && ex {
-			continue
-		}
-
 		ignoreByPath[pth] = exclude
 	}
 	return ignoreByPath

--- a/cache_path.go
+++ b/cache_path.go
@@ -58,11 +58,17 @@ func parseIncludeList(list []string) map[string]string {
 func parseIgnoreList(list []string) map[string]bool {
 	ignoreByPath := map[string]bool{}
 	for _, item := range list {
-		pth, ignore := parseIgnoreListItem(item)
+		pth, exclude := parseIgnoreListItem(item)
 		if len(pth) == 0 {
 			continue
 		}
-		ignoreByPath[pth] = ignore
+
+		ex, ok := ignoreByPath[pth]
+		if ok && ex {
+			continue
+		}
+
+		ignoreByPath[pth] = exclude
 	}
 	return ignoreByPath
 }

--- a/cache_path.go
+++ b/cache_path.go
@@ -179,6 +179,11 @@ func normalizeIndicatorByPath(indicatorByPath map[string]string) (map[string]str
 func normalizeExcludeByPattern(excludeByPattern map[string]bool) (map[string]bool, error) {
 	normalized := map[string]bool{}
 	for pattern, exclude := range excludeByPattern {
+		if strings.HasPrefix(pattern, "*") {
+			normalized[pattern] = exclude
+			continue
+		}
+
 		pattern, err := pathutil.AbsPath(pattern)
 		if err != nil {
 			return nil, err

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -230,6 +230,11 @@ func Test_parseIgnoreList(t *testing.T) {
 			list:             []string{"!"},
 			excludeByPattern: map[string]bool{},
 		},
+		{
+			name:             "same pattern different exclude option",
+			list:             []string{"!*.log", "*.log"},
+			excludeByPattern: map[string]bool{"*.log": true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -233,7 +233,7 @@ func Test_parseIgnoreList(t *testing.T) {
 		{
 			name:             "same pattern different exclude option",
 			list:             []string{"!*.log", "*.log"},
-			excludeByPattern: map[string]bool{"*.log": true},
+			excludeByPattern: map[string]bool{"*.log": false},
 		},
 	}
 	for _, tt := range tests {

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -476,15 +476,21 @@ func Test_normalizeExcludeByPattern(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name:             "expands envs in pattern",
+			name:             "expands env",
 			excludeByPattern: map[string]bool{"/$NORMALIZE_EXCLUDE_BY_PATTERN_KEY/path/to/ignore": false},
 			normalized:       map[string]bool{"/test/path/to/ignore": false},
 			wantErr:          false,
 		},
 		{
-			name:             "expands pattern",
+			name:             "expands current dir",
 			excludeByPattern: map[string]bool{"path/to/ignore": false},
 			normalized:       map[string]bool{filepath.Join(currentDir, "path/to/ignore"): false},
+			wantErr:          false,
+		},
+		{
+			name:             "does not expand if starts with wildcard",
+			excludeByPattern: map[string]bool{"*.log": false},
+			normalized:       map[string]bool{"*.log": false},
 			wantErr:          false,
 		},
 	}

--- a/cache_path_test.go
+++ b/cache_path_test.go
@@ -507,50 +507,50 @@ func Test_match(t *testing.T) {
 		name             string
 		pth              string
 		excludeByPattern map[string]bool
-		doNotTrack       bool
+		ok               bool
 		exclude          bool
 	}{
 		{
 			name:             "simple no match",
 			pth:              "path/to/include",
 			excludeByPattern: map[string]bool{"path/to/exclude": false},
-			doNotTrack:       false,
+			ok:               false,
 			exclude:          false,
 		},
 		{
 			name:             "full match",
 			pth:              "path/to/cache",
 			excludeByPattern: map[string]bool{"path/to/cache": false},
-			doNotTrack:       true,
+			ok:               true,
 			exclude:          false,
 		},
 		{
 			name:             "glob match",
 			pth:              "path/to/cache",
 			excludeByPattern: map[string]bool{"path/*/cache": false},
-			doNotTrack:       true,
+			ok:               true,
 			exclude:          false,
 		},
 		{
 			name:             "glob match",
 			pth:              "path/to/cache",
 			excludeByPattern: map[string]bool{"**/cache": false},
-			doNotTrack:       true,
+			ok:               true,
 			exclude:          false,
 		},
 		{
 			name:             "exclude",
 			pth:              "path/to/cache",
 			excludeByPattern: map[string]bool{"path/to/cache": true},
-			doNotTrack:       true,
+			ok:               true,
 			exclude:          true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			doNotTrack, exclude := match(tt.pth, tt.excludeByPattern)
-			if doNotTrack != tt.doNotTrack {
-				t.Errorf("match() doNotTrack = %v, want %v", doNotTrack, tt.doNotTrack)
+			exclude, ok := match(tt.pth, tt.excludeByPattern)
+			if ok != tt.ok {
+				t.Errorf("match() ok = %v, want %v", ok, tt.ok)
 			}
 			if exclude != tt.exclude {
 				t.Errorf("match() exclude = %v, want %v", exclude, tt.exclude)
@@ -601,6 +601,14 @@ func Test_interleave(t *testing.T) {
 			name:                "exclude match, remove",
 			indicatorByPth:      map[string]string{"path/to/cache": "indicator/path"},
 			excludeByPattern:    map[string]bool{"path/to": true},
+			indicatorByCachePth: map[string]string{},
+		},
+		{
+			name:           "both ignore and exclude match, remove",
+			indicatorByPth: map[string]string{"path/to/cache.log": "indicator/path"},
+			excludeByPattern: map[string]bool{
+				"path/to": false,
+				"*.log":   true},
 			indicatorByCachePth: map[string]string{},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -58,13 +58,31 @@ func main() {
 		logErrorfAndExit("Failed to parse include list: %s", err)
 	}
 
+	log.Debugf("Normalised include list:")
+	for path, indicator := range pathToIndicatorPath {
+		log.Debugf("%s -> %s", path, indicator)
+	}
+	log.Debugf("")
+
 	excludeByPattern := parseIgnoreList(strings.Split(configs.IgnoredPaths, "\n"))
 	excludeByPattern, err = normalizeExcludeByPattern(excludeByPattern)
 	if err != nil {
 		logErrorfAndExit("Failed to parse ignore list: %s", err)
 	}
 
+	log.Debugf("Normalised exclude list:")
+	for pattern, exclude := range excludeByPattern {
+		log.Debugf("%s: %v", pattern, exclude)
+	}
+	log.Debugf("")
+
 	pathToIndicatorPath = interleave(pathToIndicatorPath, excludeByPattern)
+
+	log.Debugf("Interleaved cache list:")
+	for path, indicator := range pathToIndicatorPath {
+		log.Debugf("%s -> %s", path, indicator)
+	}
+	log.Debugf("")
 
 	log.Donef("Done in %s\n", time.Since(startTime))
 

--- a/main.go
+++ b/main.go
@@ -12,9 +12,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
 )
 
@@ -58,11 +60,20 @@ func main() {
 		logErrorfAndExit("Failed to parse include list: %s", err)
 	}
 
-	log.Debugf("Normalised include list:")
-	for path, indicator := range pathToIndicatorPath {
-		log.Debugf("%s -> %s", path, indicator)
+	{
+		// DEBUG: include list
+		var b strings.Builder
+		b.WriteString("Normalised include list:\n")
+		for path, indicator := range pathToIndicatorPath {
+			b.WriteString(fmt.Sprintf("%s -> %s\n", path, indicator))
+		}
+		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "include_list.txt")
+		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
+			log.Warnf("failed to write debug include list: %s", err)
+		} else {
+			log.Debugf("include list: %s", pth)
+		}
 	}
-	log.Debugf("")
 
 	excludeByPattern := parseIgnoreList(strings.Split(configs.IgnoredPaths, "\n"))
 	excludeByPattern, err = normalizeExcludeByPattern(excludeByPattern)
@@ -70,19 +81,37 @@ func main() {
 		logErrorfAndExit("Failed to parse ignore list: %s", err)
 	}
 
-	log.Debugf("Normalised exclude list:")
-	for pattern, exclude := range excludeByPattern {
-		log.Debugf("%s: %v", pattern, exclude)
+	{
+		// DEBUG: exclude list
+		var b strings.Builder
+		b.WriteString("Normalised exclude list:\n")
+		for pattern, exclude := range excludeByPattern {
+			b.WriteString(fmt.Sprintf("%s: %v\n", pattern, exclude))
+		}
+		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "exclude_list.txt")
+		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
+			log.Warnf("failed to write debug exclude list: %s", err)
+		} else {
+			log.Debugf("exclude list: %s", pth)
+		}
 	}
-	log.Debugf("")
 
 	pathToIndicatorPath = interleave(pathToIndicatorPath, excludeByPattern)
 
-	log.Debugf("Interleaved cache list:")
-	for path, indicator := range pathToIndicatorPath {
-		log.Debugf("%s -> %s", path, indicator)
+	{
+		// DEBUG: cache list
+		var b strings.Builder
+		b.WriteString("Interleaved cache list:\n")
+		for path, indicator := range pathToIndicatorPath {
+			b.WriteString(fmt.Sprintf("%s -> %s\n", path, indicator))
+		}
+		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "cache_list.txt")
+		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
+			log.Warnf("failed to write debug cache list: %s", err)
+		} else {
+			log.Debugf("cache list: %s", pth)
+		}
 	}
-	log.Debugf("")
 
 	log.Donef("Done in %s\n", time.Since(startTime))
 

--- a/main.go
+++ b/main.go
@@ -12,11 +12,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
 )
 
@@ -60,58 +58,13 @@ func main() {
 		logErrorfAndExit("Failed to parse include list: %s", err)
 	}
 
-	{
-		// DEBUG: include list
-		var b strings.Builder
-		b.WriteString("Normalised include list:\n")
-		for path, indicator := range pathToIndicatorPath {
-			b.WriteString(fmt.Sprintf("%s -> %s\n", path, indicator))
-		}
-		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "include_list.txt")
-		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
-			log.Warnf("failed to write debug include list: %s", err)
-		} else {
-			log.Debugf("include list: %s", pth)
-		}
-	}
-
 	excludeByPattern := parseIgnoreList(strings.Split(configs.IgnoredPaths, "\n"))
 	excludeByPattern, err = normalizeExcludeByPattern(excludeByPattern)
 	if err != nil {
 		logErrorfAndExit("Failed to parse ignore list: %s", err)
 	}
 
-	{
-		// DEBUG: exclude list
-		var b strings.Builder
-		b.WriteString("Normalised exclude list:\n")
-		for pattern, exclude := range excludeByPattern {
-			b.WriteString(fmt.Sprintf("%s: %v\n", pattern, exclude))
-		}
-		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "exclude_list.txt")
-		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
-			log.Warnf("failed to write debug exclude list: %s", err)
-		} else {
-			log.Debugf("exclude list: %s", pth)
-		}
-	}
-
 	pathToIndicatorPath = interleave(pathToIndicatorPath, excludeByPattern)
-
-	{
-		// DEBUG: cache list
-		var b strings.Builder
-		b.WriteString("Interleaved cache list:\n")
-		for path, indicator := range pathToIndicatorPath {
-			b.WriteString(fmt.Sprintf("%s -> %s\n", path, indicator))
-		}
-		pth := filepath.Join(os.Getenv("BITRISE_DEPLOY_DIR"), "cache_list.txt")
-		if err := fileutil.WriteStringToFile(pth, b.String()); err != nil {
-			log.Warnf("failed to write debug cache list: %s", err)
-		} else {
-			log.Debugf("cache list: %s", pth)
-		}
-	}
 
 	log.Donef("Done in %s\n", time.Since(startTime))
 


### PR DESCRIPTION
Preparing for the exclusion of
- Gradle daemon logs
- previous Gradle versions related caches items

Issue fixes:
- Set exclude on cache path if any `ignore_check_on_paths` element sets it
- Do not expand `ignore_check_on_paths` element if starts with `*`