### PR TITLE
Remove default `BITRISE_CACHE_DIR` value from `cache_paths` input

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,7 +34,6 @@ workflows:
     envs:
     - TMP_DIR: $ORIG_BITRISE_SOURCE_DIR/_tmp3
     - CACHE_PATH: |
-        $BITRISE_CACHE_DIR
         ./_sample_artifacts/filestructure -> ./_sample_artifacts/filestructure/build/findme.test
         ./DoesNotExist/
         ./DoesNotExist
@@ -150,7 +149,6 @@ workflows:
         inputs:
         - is_debug_mode: true
         - cache_paths: |
-            $BITRISE_CACHE_DIR
             ../_sample_artifacts/filestructure -> ../_sample_artifacts/filestructure/build/findme.test
             ./DoesNotExist/
             ./DoesNotExist

--- a/step.yml
+++ b/step.yml
@@ -61,8 +61,7 @@ deps:
   - name: tar
 run_if: ".IsCI | and (not .IsPR)"
 inputs:
-  - cache_paths: |
-      $BITRISE_CACHE_DIR
+  - cache_paths:
     opts:
       title: "Cache paths"
       summary: Cache these paths. Separate paths with a newline.


### PR DESCRIPTION
### Checklist

- [✅ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

This directory was always added to cache but its usage was not
communicated, also it was not working on MacOS stacks. Currently we are
no longer advocating using cache to move custom files between workflows
so we remove this default.

[STEP-447]

### Changes

- Remove default `BITRISE_CACHE_DIR` value from `cache_paths` input

### Investigation details

We considered fixing the MacOS stack issue but as this mechanism is no longer advised by the team we opted to remove it instead. The same behavior can still be easily achieved if an advanced use-case requires it.


[STEP-447]: https://bitrise.atlassian.net/browse/STEP-447