### PR TITLE
Extract archive info model in a new package

### DIFF
--- a/model/archive_info.go
+++ b/model/archive_info.go
@@ -1,0 +1,20 @@
+package model
+
+import "fmt"
+
+const (
+	// Version ...
+	Version = 2
+)
+
+// ArchiveInfo ...
+type ArchiveInfo struct {
+	Version      uint64 `json:"version,omitempty"`
+	StackID      string `json:"stack_id,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}
+
+// String ...
+func (a ArchiveInfo) String() string {
+	return fmt.Sprintf("%s (%s)", a.StackID, a.Architecture)
+}

--- a/stack_info.go
+++ b/stack_info.go
@@ -3,18 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/bitrise-steplib/steps-cache-push/model"
 )
 
 func stackVersionData(stackID, architecture string) ([]byte, error) {
-	type archiveInfo struct {
-		Version     uint64 `json:"version,omitempty"`
-		StackID     string `json:"stack_id,omitempty"`
-		Arhitecture string `json:"architecture,omitempty"`
-	}
-	stackData, err := json.Marshal(archiveInfo{
-		Version:     2,
-		StackID:     stackID,
-		Arhitecture: architecture,
+	stackData, err := json.Marshal(model.ArchiveInfo{
+		Version:      model.Version,
+		StackID:      stackID,
+		Architecture: architecture,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal data, error: %s", err)


### PR DESCRIPTION
Extract the `ArchiveInfo` struct in a separate package to share it with the cache-pull step.
